### PR TITLE
Add new Core/Export/ZipCompressionLevel setting and default to BestCompression

### DIFF
--- a/src/SIM.Base/FileSystem/UncZipProvider.cs
+++ b/src/SIM.Base/FileSystem/UncZipProvider.cs
@@ -51,7 +51,7 @@ namespace SIM.FileSystem
       }
     }
 
-    public override void CreateZip(string path, string zipFileName, string ignore = null)
+    public override void CreateZip(string path, string zipFileName, string ignore = null, int compressionLevel = 0)
     {
       try
       {

--- a/src/SIM.Base/FileSystem/ZipProvider.cs
+++ b/src/SIM.Base/FileSystem/ZipProvider.cs
@@ -65,11 +65,20 @@ namespace SIM.FileSystem
       }
     }
 
-    public virtual void CreateZip(string path, string zipFileName, string ignore = null)
+    public virtual void CreateZip(string path, string zipFileName, string ignore = null, int compressionLevel = 0)
     {
+      CompressionLevel zipCompressionLevel;
+      if (typeof(CompressionLevel).IsEnumDefined(compressionLevel))
+      {
+        zipCompressionLevel = (CompressionLevel)compressionLevel;
+      }
+      else
+      {
+        zipCompressionLevel = CompressionLevel.None;
+      }
       var zip = new ZipFile
       {
-        CompressionLevel = CompressionLevel.None, 
+        CompressionLevel = zipCompressionLevel,
         UseZip64WhenSaving = Zip64Option.AsNecessary
       };
       if (ignore == null)

--- a/src/SIM.Pipelines/Export/ExportPostActions.cs
+++ b/src/SIM.Pipelines/Export/ExportPostActions.cs
@@ -1,5 +1,6 @@
 ﻿namespace SIM.Pipelines.Export
 {
+  using SIM.Pipelines.Install;
   internal class ExportPostActions : ExportProcessor
   {
     #region Protected methods
@@ -7,7 +8,7 @@
     protected override void Process(ExportArgs args)
     {
       var zipName = args.ExportFile;
-      FileSystem.FileSystem.Local.Zip.CreateZip(args.Folder, zipName);
+      FileSystem.FileSystem.Local.Zip.CreateZip(args.Folder, zipName, compressionLevel: Settings.CoreExportZipCompressionLevel.Value);
     }
 
     #endregion

--- a/src/SIM.Pipelines/Install/Settings.cs
+++ b/src/SIM.Pipelines/Install/Settings.cs
@@ -16,6 +16,8 @@
     public static readonly AdvancedProperty<string> CoreExportTempFolderLocation = AdvancedSettings.Create("Core/Export/TempFolder/Location", string.Empty);
 
     [NotNull]
+    public static readonly AdvancedProperty<int> CoreExportZipCompressionLevel = AdvancedSettings.Create("Core/Export/ZipCompressionLevel", 9);
+    [NotNull]
     public static readonly AdvancedProperty<bool> CoreInstallDictionaries = AdvancedSettings.Create("Core/Install/Dictionaries", false);
 
     [NotNull]


### PR DESCRIPTION
We are using SIM in our build process to generate zips and this setting means generated zips are over a gigabyte smaller.
