### PR TITLE
Refactored InstanceDetails.xaml.cs to remove ComboBox dependency in code

### DIFF
--- a/src/SIM.Tool.Windows/UserControls/Install/InstanceDetails.xaml.cs
+++ b/src/SIM.Tool.Windows/UserControls/Install/InstanceDetails.xaml.cs
@@ -7,6 +7,7 @@
   using System.Linq;
   using System.Windows;
   using System.Windows.Controls;
+  using System.Windows.Controls.Primitives;
   using System.Xml;
   using SIM.Adapters.SqlServer;
   using SIM.Adapters.WebServer;
@@ -333,7 +334,7 @@
       this.SelectLast(this.ProductRevision);
     }
 
-    private void Select([NotNull] ComboBox element, [NotNull] string value)
+    private void Select([NotNull] Selector element, [NotNull] string value)
     {
       Assert.ArgumentNotNull(element, "element");
       Assert.ArgumentNotNull(value, "value");
@@ -372,7 +373,7 @@
       }
     }
 
-    private void SelectByValue([NotNull] ComboBox element, string value)
+    private void SelectByValue([NotNull] Selector element, string value)
     {
       Assert.ArgumentNotNull(element, "element");
 
@@ -405,9 +406,9 @@
         {
           foreach (var item in element.Items)
           {
-            if (item is ComboBoxItem)
+            if (item is ContentControl)
             {
-              if ((item as ComboBoxItem).Content.ToString().EqualsIgnoreCase(value, true))
+              if ((item as ContentControl).Content.ToString().EqualsIgnoreCase(value, true))
               {
                 element.SelectedItem = item;
                 break;
@@ -427,7 +428,7 @@
       }
     }
 
-    private void SelectFirst([NotNull] ComboBox element)
+    private void SelectFirst([NotNull] Selector element)
     {
       Assert.ArgumentNotNull(element, "element");
 
@@ -437,7 +438,7 @@
       }
     }
 
-    private void SelectLast([NotNull] ComboBox element)
+    private void SelectLast([NotNull] Selector element)
     {
       Assert.ArgumentNotNull(element, "element");
 
@@ -447,7 +448,7 @@
       }
     }
 
-    private void SelectProductByValue([CanBeNull] ComboBox element, [NotNull] string value)
+    private void SelectProductByValue([CanBeNull] Selector element, [NotNull] string value)
     {
       Assert.ArgumentNotNull(value, "value");
 


### PR DESCRIPTION
Change doesn't affect logic somehow and just replaces UI component classes usage with more generic ones:
`ComboBox` => `Selector`
`ComboBoxItem` => `ContentControl` 


I need that change to avoid code merging in my custom plugin each time the SIM code is updated.