### PR TITLE
Added admin check & indicator

### DIFF
--- a/src/SIM.Tool.Windows/MainWindow.xaml.cs
+++ b/src/SIM.Tool.Windows/MainWindow.xaml.cs
@@ -46,7 +46,8 @@
           this.MaxWidth = this.MinWidth;
         }
 
-        this.Title = string.Format(this.Title, ApplicationManager.AppShortVersion, ApplicationManager.AppLabel);
+        this.Title = string.Format(this.Title, ApplicationManager.AppShortVersion, ApplicationManager.AppLabel)
+            + (IsRunningAsAdministrator() ? " (Administrator)" : string.Empty);
 
         this.timer =
           new System.Threading.Timer(
@@ -227,6 +228,13 @@
       {
         this.HandleError(ex);
       }
+    }
+
+    private static bool IsRunningAsAdministrator()
+    {
+      var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
+      var principal = new System.Security.Principal.WindowsPrincipal(identity);
+      return principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
     }
 
     private void ItemsTreeViewKeyPressed([CanBeNull] object sender, [NotNull] KeyEventArgs e)


### PR DESCRIPTION
Given this can run with/without UAC, thought having it indicate the context in which it's being ran would be helpful. A step further would be to disallow operations if the required [elevated] permission is absent (as I've caught myself, on occasion, fouling up installs because it failed permissions to inetpub), but this may be a more subtle step in that direction.