### PR TITLE
added support for MSSQL default intances with windows authentication

### DIFF
--- a/src/SIM.Pipelines/AttachDatabasesHelper.cs
+++ b/src/SIM.Pipelines/AttachDatabasesHelper.cs
@@ -260,8 +260,7 @@ namespace SIM.Pipelines
 
       SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(defaultConnectionString.ConnectionString)
       {
-        InitialCatalog = connectionString.GenerateDatabaseName(name), 
-        IntegratedSecurity = false
+        InitialCatalog = connectionString.GenerateDatabaseName(name)
       };
       connectionString.Value = builder.ToString();
       connectionString.SaveChanges();

--- a/src/SIM.Tool/App.xaml.cs
+++ b/src/SIM.Tool/App.xaml.cs
@@ -242,7 +242,7 @@ namespace SIM.Tool
     {
       try
       {
-        using (var sc = new ServiceController("World Wide Web Publishing Service"))
+          using (var sc = new ServiceController("W3SVC"))
         {
           Log.Info("IIS.Name: {0}", sc.DisplayName);
           Log.Info("IIS.Status: {0}", sc.Status);


### PR DESCRIPTION
Removed the "IntegratedSecurity = false" property, so Integrated Secutiy will not be disabled on a new instance when using connection strings like 'Data Source=.;Integrated Security=True'.

Fixed also an issue on non-english windows version where the 'IIS Check' does not work.

