### PR TITLE
Grant button doesn't help when user gets an error in SQL Server

### DIFF
--- a/src/SIM.Adapters/SqlServer/SqlServerManager.cs
+++ b/src/SIM.Adapters/SqlServer/SqlServerManager.cs
@@ -602,7 +602,7 @@
       }
     }
 
-    public virtual bool TestSqlServer(string rootPath, string connectionString)
+    public virtual void TestSqlServer(string rootPath, string connectionString)
     {
       var createDatabase = string.Format("CREATE DATABASE TestDatabase ON PRIMARY (NAME = TestDatabase_Data, FILENAME = '{0}\\TestDatabase.mdf', SIZE = 20MB, MAXSIZE = 100MB, FILEGROWTH = 10%) " +
                                          "LOG ON (NAME = TestDatabase_Log, FILENAME = '{0}\\TestDatabase.ldf', SIZE = 10MB, MAXSIZE = 50MB, FILEGROWTH = 10%)", rootPath);
@@ -625,14 +625,12 @@
 
 
           command.ExecuteNonQuery();
-          return true;
         }
       }
       catch (Exception ex)
       {
         Log.Error(ex, "Cannot create a test database");
-
-        return false;
+        throw;
       }
     }
 

--- a/src/SIM.Tool.Windows/UserControls/Setup/ConnectionString.xaml.cs
+++ b/src/SIM.Tool.Windows/UserControls/Setup/ConnectionString.xaml.cs
@@ -4,6 +4,7 @@
   using System.Data.SqlClient;
   using System.Windows;
   using System.Windows.Controls;
+  using SIM.Adapters.SqlServer;
   using SIM.Tool.Base;
   using SIM.Tool.Base.Wizards;
   using SIM.Tool.Windows.Dialogs;
@@ -42,6 +43,9 @@
       {
         connection = SIM.Adapters.SqlServer.SqlServerManager.Instance.OpenConnection(new SqlConnectionStringBuilder(args.ConnectionString), true);
         connection.Close();
+
+        SqlServerManager.Instance.TestSqlServer(args.InstancesRootFolderPath, args.ConnectionString);
+
         return true;
       }
       catch (SqlException ex)

--- a/src/SIM.Tool.Windows/UserControls/Setup/Permissions.xaml.cs
+++ b/src/SIM.Tool.Windows/UserControls/Setup/Permissions.xaml.cs
@@ -153,12 +153,6 @@
           }
         }
 
-        if (!SqlServerManager.Instance.TestSqlServer(args.InstancesRootFolderPath, args.ConnectionString))
-        {
-          WindowHelper.ShowMessage(message, MessageBoxButton.OK, MessageBoxImage.Error, MessageBoxResult.OK);
-          return false;
-        }
-
         return true;
       }
       catch (Exception ex)


### PR DESCRIPTION
When SIM user clicks next on Permission step he gets this message: 

> You probably don't have necessary permissions set. Please try to click 'Grant' button before you proceed.

Trying to click "Grant" button doesn't do anything if `SqlServerManager.Instance.TestSqlServer` fails in `Permissions.OnMovingNext` method i.e. with this message:

> CREATE DATABASE permission denied in database 'master'.

`SqlServerManager.Instance.TestSqlServer` returns false and message suggests to SIM user to click "Grant" button again, which doesn't make sense,

 So I would recommend to move calling of `TestSqlServer` method to the `ConnectionString.OnMovingNext` method or to change message to more appropriate.
