### PR TITLE
Force manifest to reload, and general cleanup

### DIFF
--- a/src/SIM.Base/ApplicationManager.cs
+++ b/src/SIM.Base/ApplicationManager.cs
@@ -178,8 +178,6 @@ namespace SIM
 
       var assembly = Assembly.Load(assemblyName);
       Assert.IsNotNull(assembly, "assembly");
-      Assert.IsNotNull(assembly, "assembly");
-      Assert.IsNotNull(assembly, "assembly");
 
       using (var stream = assembly.GetManifestResourceStream(assemblyName + @"." + packageName))
       {

--- a/src/SIM.Base/ReflectionUtil.cs
+++ b/src/SIM.Base/ReflectionUtil.cs
@@ -4,6 +4,7 @@
   using Sitecore.Diagnostics.Base;
   using Sitecore.Diagnostics.Base.Annotations;
   using Sitecore.Diagnostics.Logging;
+  using System.Reflection;
 
   public static class ReflectionUtil
   {
@@ -42,6 +43,45 @@
       Assert.IsNotNull(type, "The {0} type cannot be found in the assemblies".FormatWith(typeName));
 
       return type;
+    }
+
+    [NotNull]
+    public static Type GetType(Assembly assembly, string typeName)
+    {
+      Assert.ArgumentNotNull(assembly, "assembly");
+      Assert.ArgumentNotNull(typeName, "typeName");
+
+      Type type = assembly.GetType(typeName);
+      Assert.IsNotNull(type,
+        "The {0} type cannot be loaded in the {1} assembly.".FormatWith(typeName, assembly.FullName));
+
+      return type;
+    }
+
+    [NotNull]
+    public static Assembly GetAssembly(string dllPath)
+    {
+      Assert.ArgumentNotNullOrEmpty(dllPath, "dllPath");
+
+      Assembly assembly = Assembly.LoadFrom(dllPath);
+      Assert.IsNotNull(assembly, "The assembly cannot be loaded from the path '{0}'.".FormatWith(dllPath));
+
+      return assembly;
+    }
+
+    [CanBeNull]
+    public static object InvokeMethod(object obj, string method, params object[] parameters)
+    {
+      Assert.ArgumentNotNull(obj, "obj");
+      Assert.ArgumentNotNullOrEmpty(method, "method");
+
+      Type type = obj.GetType();
+
+      MethodInfo methodInfo = type.GetMethod(method);
+      Assert.IsNotNull(methodInfo,
+        "The {0} method cannot be loaded from the {1} type.".FormatWith(method, type.FullName));
+
+      return methodInfo.Invoke(obj, parameters);
     }
 
     #endregion

--- a/src/SIM.Pipelines/ConfigurationActions.cs
+++ b/src/SIM.Pipelines/ConfigurationActions.cs
@@ -954,7 +954,6 @@ namespace SIM.Pipelines
       var targetPath = Path.Combine(instanceRootPath, target.TrimStart("/"));
 
       File.Copy(sourcePath, targetPath);
-
     }
 
     private static void SetRestrictingPlaceholders(string names, string url)

--- a/src/SIM.Pipelines/ConfigurationActions.cs
+++ b/src/SIM.Pipelines/ConfigurationActions.cs
@@ -60,6 +60,7 @@ namespace SIM.Pipelines
           continue;
         }
 
+        module.ResetManifest();
         XmlDocument manifest = module.Manifest;
 
         if (manifest == null)

--- a/src/SIM.Pipelines/Install/Modules/CreateSolrCores.cs
+++ b/src/SIM.Pipelines/Install/Modules/CreateSolrCores.cs
@@ -1,58 +1,53 @@
 ﻿using System;
 using System.CodeDom;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Reflection;
 using System.Xml;
+using Sitecore.Diagnostics.Base;
 using SIM.Instances;
 using SIM.Pipelines.InstallModules;
 using SIM.Products;
 
 namespace SIM.Pipelines.Install.Modules
 {
-  public class CreateSolrCore : IPackageInstallActions
+  /// <summary>
+  /// Creates cores for all configured Solr indexes
+  /// </summary>
+  public class CreateSolrCores : IPackageInstallActions
   {
 
-    private const string DefaultCollectionName = "collection1";
+    #region Constants
 
-    /// <summary>
-    /// Wrap WebRequestHelper for unit testing.
-    /// </summary>
-    /// <param name="url"></param>
-    /// <returns></returns>
-    public virtual HttpWebResponse RequestAndGetResponse(string url)
-    {
-      return WebRequestHelper.RequestAndGetResponse(url);
-    }
+    private const string GenerateSchemaClass = "Sitecore.ContentSearch.ProviderSupport.Solr.SchemaGenerator";
+    private const string GenerateSchemaMethod = "GenerateSchema";
 
+    #endregion
+
+    #region Public methods
 
     public void Execute(Instance instance, Product module)
     {
       XmlDocument config = instance.GetShowconfig();
-      string url = GetUrl(config);
-
+      string solrUrl = GetUrl(config);
       XmlNodeList solrIndexes = GetSolrIndexNodes(config);
-
-
-      string defaultCollectionPath = GetDefaultCollectionPath(url);
-      
+      string defaultCollectionPath = GetDefaultCollectionPath(solrUrl);
 
       foreach (XmlElement node in solrIndexes)
       {
-        var coreName = GetCoreName(node);
-
-        string corePath = defaultCollectionPath.Replace(DefaultCollectionName, coreName);
-
+        string coreName = GetCoreName(node);
+        string corePath = defaultCollectionPath.Replace("collection1", coreName);
         this.CopyDirectory(defaultCollectionPath, corePath);
-
         DeleteCopiedCorePropertiesFile(corePath);
-
         UpdateSchema(instance.WebRootPath, corePath);
-
-        CallSolrCreateCoreAPI(url, coreName, corePath);
-         
+        CallSolrCreateCoreAPI(solrUrl, coreName, corePath);
       }
     }
+
+    #endregion
+
+    #region Private methods
 
     private static XmlNodeList GetSolrIndexNodes(XmlDocument config)
     {
@@ -62,23 +57,31 @@ namespace SIM.Pipelines.Install.Modules
 
     private static string GetUrl(XmlDocument config)
     {
-      return config.SelectSingleNode("/sitecore/settings/setting[@name='ContentSearch.Solr.ServiceBaseAddress']").Attributes["value"].Value;
+      XmlNode serviceBaseAddressNode = config.SelectSingleNode("/sitecore/settings/setting[@name='ContentSearch.Solr.ServiceBaseAddress']");
+      serviceBaseAddressNode = Assert.IsNotNull(serviceBaseAddressNode,
+        "ContentSearch.Solr.ServiceBaseAddress not found in configuration.");
+
+      XmlAttribute valueAttribute = serviceBaseAddressNode.Attributes["value"];
+      Assert.IsNotNull(valueAttribute, "ContentSearch.Solr.ServiceBaseAddress value attribute not found.");
+      return valueAttribute.Value;
     }
 
     private void UpdateSchema(string webRootPath, string corePath)
     {
       string contentSearchDllPath = webRootPath.EnsureEnd(@"\") + @"bin\Sitecore.ContentSearch.dll";
-      string schemaPath = corePath.EnsureEnd(@"\") + @"conf\schema.xml"; 
-      string managedSchemaPath = corePath.EnsureEnd(@"\") + @"conf\managed-schema.xml";  //TODO Wrong name
+      string schemaPath = corePath.EnsureEnd(@"\") + @"conf\schema.xml";
+      string managedSchemaPath = corePath.EnsureEnd(@"\") + @"conf\managed-schema";
 
       bool schemaExists = FileExists(schemaPath);
       bool managedSchemaExists = FileExists(managedSchemaPath);
 
-      if (!schemaExists && !managedSchemaExists) throw new FileNotFoundException(string.Format("Schema file not found: Checked here {0} and here {1}.", schemaPath, managedSchemaPath));
+      if (!schemaExists && !managedSchemaExists)
+      {
+        throw new FileNotFoundException(string.Format("Schema file not found: Checked here {0} and here {1}.", schemaPath, managedSchemaPath));
+      }
 
       string inputPath = managedSchemaExists ? managedSchemaPath : schemaPath;
       string outputPath = schemaPath;
-
       this.GenerateSchema(contentSearchDllPath, inputPath, outputPath);
     }
 
@@ -86,13 +89,14 @@ namespace SIM.Pipelines.Install.Modules
     {
       var coreElement = node.SelectSingleNode("param[@desc='core']") as XmlElement;
       string id = node.Attributes["id"].InnerText;
+      coreElement = Assert.IsNotNull(coreElement, "param[@desc='core'] not found in Solr configuration file");
       string coreName = coreElement.InnerText.Replace("$(id)", id);
       return coreName;
     }
 
     private void CallSolrCreateCoreAPI(string url, string coreName, string instanceDir)
     {
-      HttpWebResponse response = this.RequestAndGetResponse(string.Format(
+      this.RequestAndGetResponse(string.Format(
         "{0}/admin/cores?action=CREATE&name={1}&instanceDir={2}&config=solrconfig.xml&schema=schema.xml&dataDir=data", url, coreName, instanceDir));
     }
 
@@ -106,7 +110,7 @@ namespace SIM.Pipelines.Install.Modules
     {
       var response = this.RequestAndGetResponse(string.Format(
         "{0}/admin/cores", url));
-      
+
       var doc = new XmlDocument();
       doc.Load(response.GetResponseStream());
 
@@ -116,11 +120,19 @@ namespace SIM.Pipelines.Install.Modules
       return collection1Node.SelectSingleNode("str[@name='instanceDir']").InnerText;
     }
 
-    #region System calls are virtual for unit testing
+    #endregion
+
+    #region Virtual methods
+    // All system calls are wrapped in virtual methods for unit testing.
+
+    public virtual HttpWebResponse RequestAndGetResponse(string url)
+    {
+      return WebRequestHelper.RequestAndGetResponse(url);
+    }
 
     public virtual void CopyDirectory(string sourcePath, string destinationPath)
     {
-      FileSystem.FileSystem.Local.Directory.Copy(sourcePath, destinationPath, recursive:true);
+      FileSystem.FileSystem.Local.Directory.Copy(sourcePath, destinationPath, recursive: true);
     }
 
     public virtual void WriteAllText(string path, string text)
@@ -139,20 +151,15 @@ namespace SIM.Pipelines.Install.Modules
     }
 
     /// <summary>
-    /// Dynamically loads GenerateSchema class from target site.
-    /// See https://msdn.microsoft.com/en-us/library/1009fa28(v=vs.110).aspx
-    /// https://msdn.microsoft.com/en-us/library/system.reflection.methodinfo.invoke(v=vs.110).aspx
+    /// Dynamically loads GenerateSchema class from target site, and uses it
+    /// to applied required changes to the Solr schema.xml file.
     /// </summary>
-    /// <param name="path"></param>
-    /// <param name="dllPath"></param>
-    /// <param name="schemaPath"></param>
     public virtual void GenerateSchema(string dllPath, string inputPath, string outputPath)
     {
-      var assembly = Assembly.LoadFrom(dllPath);
-      var generateSchema = assembly.GetType("Sitecore.ContentSearch.ProviderSupport.Solr.SchemaGenerator");
-      var obj = Activator.CreateInstance(generateSchema);
-      var method = generateSchema.GetMethod("GenerateSchema");
-      method.Invoke(obj, new object[] {inputPath, outputPath});
+      Assembly assembly = ReflectionUtil.GetAssembly(dllPath);
+      Type generateSchema = ReflectionUtil.GetType(assembly, GenerateSchemaClass);
+      object obj = ReflectionUtil.CreateObject(generateSchema);
+      ReflectionUtil.InvokeMethod(obj, GenerateSchemaMethod, inputPath, outputPath);
     }
 
     #endregion

--- a/src/SIM.Pipelines/SIM.Pipelines.csproj
+++ b/src/SIM.Pipelines/SIM.Pipelines.csproj
@@ -107,7 +107,7 @@
     <Compile Include="InstallModules\IPackageInstallActions.cs" />
     <Compile Include="Install\0150 GrantPermissions.cs" />
     <Compile Include="Install\0600 UpdateWebConfig.cs" />
-    <Compile Include="Install\Modules\CreateSolrCore.cs" />
+    <Compile Include="Install\Modules\CreateSolrCores.cs" />
     <Compile Include="Install\Modules\SwitchConfigsToSolr.cs" />
     <Compile Include="Install\Settings.cs" />
     <Compile Include="MongoHelper.cs" />

--- a/src/SIM.Products/Product.cs
+++ b/src/SIM.Products/Product.cs
@@ -759,5 +759,13 @@
     }
 
     #endregion
+
+    /// <summary>
+    /// Force manifest to be reloaded from disk, to reset variable replacements.
+    /// </summary>
+    public void ResetManifest()
+    {
+      this.manifest = null;
+    }
   }
 }

--- a/src/SIM.Tool/Manifests/Modules/Sitecore.Solr.Support.manifest.xml
+++ b/src/SIM.Tool/Manifests/Modules/Sitecore.Solr.Support.manifest.xml
@@ -22,7 +22,7 @@
                     target="/Website/bin/Castle.Core.dll" />
         <deployfile path="SIM.Pipelines/IOC_Containers.zip/IOC_Containers/Castle.Windsor.dll"    
                     target="/Website/bin/Castle.Windsor.dll" />
-        <custom type="SIM.Pipelines.Install.Modules.CreateSolrCore, SIM.Pipelines" />
+        <custom type="SIM.Pipelines.Install.Modules.CreateSolrCores, SIM.Pipelines" />
       </actions>
     </install>
   </archive>


### PR DESCRIPTION
This fixes Sitecore#96 (old variables replacements getting "stuck" in memory), and also includes a little bit of cleanup:
* Moved some of the reflection logic to ReflectionUtils.
* Renamed CreateSolrCore to CreateSolrCores, since it creates cores for all indexes.
* Cleaned up formatting and added regions to follow existing style.
* Corrected the name of `managed-schema` by removing the .xml suffix.
* Added null checks
* Removed duplicate assert statements created during merge..