### PR TITLE
Move Folder functionality for manifest scripts

### DIFF
--- a/src/SIM.Pipelines/ConfigurationActions.cs
+++ b/src/SIM.Pipelines/ConfigurationActions.cs
@@ -353,6 +353,14 @@
               FileSystem.FileSystem.Local.File.Move(path, destFileName);
               break;
             }
+            
+          case "movefolder":
+            {
+              var target = child.GetAttribute("target");
+              var destPath = Path.Combine(instanceRootPath, target.TrimStart('/'));
+              FileSystem.FileSystem.Local.Directory.Move(path, destPath);
+              break;
+            }
 
           case "copy":
             {


### PR DESCRIPTION
Adds case statement "movefolder" to allow scripts to relocate folder content from one place to another.