### PR TITLE
Typo fix for bug #109

### DIFF
--- a/src/SIM.Tool.Windows/UserControls/Install/InstanceDetails.xaml.cs
+++ b/src/SIM.Tool.Windows/UserControls/Install/InstanceDetails.xaml.cs
@@ -1,4 +1,4 @@
-﻿namespace SIM.Tool.Windows.UserControls.Install
+namespace SIM.Tool.Windows.UserControls.Install
 {
   using System;
   using System.Collections.Generic;
@@ -222,12 +222,15 @@
             return null;
           }
 
-          if (WindowHelper.ShowMessage("There website with the same name already exists, but points to non-existing location. Would you like to delete it?", MessageBoxButton.OKCancel, MessageBoxImage.Asterisk) != MessageBoxResult.OK)
-          {
-            return null;
-          }
+            if (
+                WindowHelper.ShowMessage(
+                    "A website with the name " + name + " already exists. Would you like to remove it?",
+                    MessageBoxButton.OKCancel, MessageBoxImage.Asterisk) != MessageBoxResult.OK)
+            {
+                return null;
+            }
 
-          site.Delete();
+            site.Delete();
           context.CommitChanges();
         }
       }


### PR DESCRIPTION
"There website with the same name already exists, but points to non-existing location. Would you like to delete it?" text is changed to "A website with the name "INSERT NAME" already exists. Would you like to remove it?"

![image](https://cloud.githubusercontent.com/assets/3874980/20571788/e5867c04-b1ce-11e6-8807-5cee51d47e16.png)
