### PR TITLE
Better SQL data file naming convention

### DIFF
--- a/src/SIM.Pipelines/AttachDatabasesHelper.cs
+++ b/src/SIM.Pipelines/AttachDatabasesHelper.cs
@@ -69,7 +69,7 @@ namespace SIM.Pipelines
       
       // Assert again
       databasePath = newPath;
-      FileSystem.Local.File.AssertExists(databasePath, databasePath + " file doesn't exist");s
+      FileSystem.Local.File.AssertExists(databasePath, databasePath + " file doesn't exist");
 
       if (SqlServerManager.Instance.DatabaseExists(databaseName, defaultConnectionString))
       {

--- a/src/SIM.Pipelines/AttachDatabasesHelper.cs
+++ b/src/SIM.Pipelines/AttachDatabasesHelper.cs
@@ -59,6 +59,18 @@ namespace SIM.Pipelines
 
       FileSystem.Local.File.AssertExists(databasePath, databasePath + " file doesn't exist");
 
+      // Make the database data file also matching databaseName
+      var newPath = databasePath.Replace(connectionString.DefaultFileName, string.Concat(databaseName, ".mdf"));
+      try
+      { 
+        File.Move(databasePath, newPath);
+      }
+      catch { }
+      
+      // Assert again
+      databasePath = newPath;
+      FileSystem.Local.File.AssertExists(databasePath, databasePath + " file doesn't exist");s
+
       if (SqlServerManager.Instance.DatabaseExists(databaseName, defaultConnectionString))
       {
         databaseName = ResolveConflict(defaultConnectionString, connectionString, databasePath, databaseName, controller);


### PR DESCRIPTION
The attaching database process always uses the default data file name (e.g. Sitecore_core.mdf) and because SIM only attaches the mdf file (now), the ldf file is left to the SQL server to be created automatically once the mdf is attached, in a user-defined logs folder. Since the ldf file came from Sitecore zip file is always the same name this creates an issue when installing another instance it fails to automatically create the ldf file because the same name is always used so the first time it will be fine but not later times (ldf file already exists error).

This pull request contains a fix by changing the default mdf file name to a custom version based on the prefix user entered in the interface so the actually data file attached will be named something like <customPrefix>_core.mdf based on project perhaps. And SQL will create corresponding ldf file based on the name of mdf file and it will be fine.

Note: this is somewhat related to issue #56.