### PR TITLE
#133 Remove instance Preheat for Log In as Admin button

### DIFF
--- a/src/SIM.Tool.Base/AuthenticationHelper.cs
+++ b/src/SIM.Tool.Base/AuthenticationHelper.cs
@@ -17,7 +17,7 @@
       Assert.ArgumentNotNull(instance, nameof(instance));
       Assert.ArgumentNotNull(owner, nameof(owner));
 
-      if (!InstanceHelperEx.PreheatInstance(instance, owner, true))
+      if (!InstanceHelperEx.PreheatInstance(instance, owner))
       {
         return;
       }

--- a/src/SIM.Tool.Base/InstanceHelperEx.cs
+++ b/src/SIM.Tool.Base/InstanceHelperEx.cs
@@ -186,14 +186,14 @@ namespace SIM.Tool.Base
       AuthenticationHelper.LoginAsAdmin(instance, owner, pageUrl, browser, parameters);
     }
 
-    public static bool PreheatInstance(Instance instance, Window mainWindow, bool ignoreAdvancedSetting = false)
+    public static bool PreheatInstance(Instance instance, Window mainWindow)
     {
       if (!EnsureAppPoolState(instance, mainWindow))
       {
         return false;
       }
 
-      if (!WinAppSettings.AppPreheatEnabled.Value && !ignoreAdvancedSetting)
+      if (!WinAppSettings.AppPreheatEnabled.Value)
       {
         return true;
       }


### PR DESCRIPTION
As it was discussed in the #133 the Log in As Admin button should respect the preheat setting value.