### PR TITLE
Restore missing 'MSTest.TestAdapter' nuget package

### DIFF
--- a/src/SIM.Client.UnitTests/packages.config
+++ b/src/SIM.Client.UnitTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="MSTest.TestAdapter" version="1.1.11" targetFramework="net452" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net452" />


### PR DESCRIPTION
Addresses #179.