### PR TITLE
Add error handling when connecting to the SIM auto-update

### DIFF
--- a/src/SIM.Tool/App.xaml.cs
+++ b/src/SIM.Tool/App.xaml.cs
@@ -85,9 +85,20 @@ namespace SIM.Tool
       // invoke auto-updater if not developing or debugging
       if (!ApplicationManager.IsDev && !ApplicationManager.IsDebugging)
       {
-        var prefix = ApplicationManager.IsQa ? "qa/" : "";
-        var suffix = ApplicationManager.IsQa ? ".QA" : "";
-        CoreApp.RunApp("rundll32.exe", $"dfshim.dll,ShOpenVerbApplication http://dl.sitecore.net/updater/{prefix}sim/SIM.Tool{suffix}.application");
+        try
+        {
+          var prefix = ApplicationManager.IsQa ? "qa/" : "";
+          var suffix = ApplicationManager.IsQa ? ".QA" : "";
+          CoreApp.RunApp("rundll32.exe", $"dfshim.dll,ShOpenVerbApplication http://dl.sitecore.net/updater/{prefix}sim/SIM.Tool{suffix}.application");
+        }
+        catch (Exception ex)
+        {
+          Log.Error(ex, $"Error connecting to SIM auto-updater.");
+          WindowHelper.ShowMessage("Cannot connect to SIM auto-updater. Check the log for additional information.", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+
+          // Get out now, but maybe ok to continue without update?
+          return;
+        }
       }
 
       if (CoreApp.HasBeenUpdated)

--- a/src/SIM.Tool/App.xaml.cs
+++ b/src/SIM.Tool/App.xaml.cs
@@ -93,7 +93,7 @@ namespace SIM.Tool
         }
         catch (Exception ex)
         {
-          Log.Error(ex, $"Error connecting to SIM auto-updater.");
+          Log.Error(ex, "Error connecting to SIM auto-updater.");
           WindowHelper.ShowMessage("Cannot connect to SIM auto-updater. Check the log for additional information.", MessageBoxButton.OK, MessageBoxImage.Exclamation);
 
           // Get out now, but maybe ok to continue without update?


### PR DESCRIPTION
The purpose of this PR is to add some error handling and logging when the user is trying to connect to the SIM auto-updater. Without the error handling, the program can crash unexpectedly (due to connection errors) and leave the user without much clue as to what happened.