### PR TITLE
Ignore Mongo connection issues when removing an instance

### DIFF
--- a/src/SIM.Pipelines/Delete/SafeDeleteMongoDatabases.cs
+++ b/src/SIM.Pipelines/Delete/SafeDeleteMongoDatabases.cs
@@ -1,0 +1,26 @@
+using JetBrains.Annotations;
+using MongoDB.Driver;
+using Sitecore.Diagnostics.Logging;
+
+namespace SIM.Pipelines.Delete
+{
+  /// <summary>
+  /// Ignores <see cref="MongoConnectionException"/> so that it is possible to 
+  /// uninstall a Sitecore instance even if there is no Mongo service running.
+  /// </summary>
+  [UsedImplicitly]
+  public class SafeDeleteMongoDatabases : DeleteMongoDatabases
+  {
+    protected override void Process([NotNull] DeleteArgs args)
+    {
+      try
+      {
+        base.Process(args);
+      }
+      catch (MongoConnectionException ex)
+      {
+        Log.Warn(ex, "Unable to delete Mongo databases.");
+      }
+    }
+  }
+}

--- a/src/SIM.Pipelines/PipelinesConfig.cs
+++ b/src/SIM.Pipelines/PipelinesConfig.cs
@@ -70,7 +70,7 @@
       <processor type=""SIM.Pipelines.Delete.StopInstance, SIM.Pipelines"" title=""Stopping application"" />
       <processor type=""SIM.Pipelines.Delete.DeleteDataFolder, SIM.Pipelines"" title=""Deleting data folder"" />
       <processor type=""SIM.Pipelines.Delete.DeleteDatabases, SIM.Pipelines"" title=""Deleting databases"" />
-      <processor type=""SIM.Pipelines.Delete.DeleteMongoDatabases, SIM.Pipelines"" title=""Deleting databases"" />
+      <processor type=""SIM.Pipelines.Delete.SafeDeleteMongoDatabases, SIM.Pipelines"" title=""Deleting databases"" />
       <processor type=""SIM.Pipelines.Delete.DeleteWebsiteFolder, SIM.Pipelines"" title=""Deleting website folder"" />
     </step>
     <step>

--- a/src/SIM.Pipelines/SIM.Pipelines.csproj
+++ b/src/SIM.Pipelines/SIM.Pipelines.csproj
@@ -93,6 +93,7 @@
     <Compile Include="ConfigurationActions.cs" />
     <Compile Include="Delete\DeleteMongoDatabases.cs" />
     <Compile Include="Delete\DeleteRegistryKey.cs" />
+    <Compile Include="Delete\SafeDeleteMongoDatabases.cs" />
     <Compile Include="Export\ExportMongoDatabases.cs" />
     <Compile Include="Import\ImportHostNames.cs" />
     <Compile Include="Import\ImportRestoreMongoDatabases.cs" />


### PR DESCRIPTION
Addresses #184.

This PR suggests ignoring MongoDb connection issues so that there is no garbage left after [unsuccessful instance removing](https://github.com/Sitecore/Sitecore-Instance-Manager/issues/184#issuecomment-320092902).

From the other side that might lead to (IMO) pretty rare case when an instance mongo databases _will not_ be removed because of connection string issues and the user won't be informed about that (only log record contains this info). Let me know if there are any concerns about that.