### PR TITLE
Add simple editor config to set indent size 2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{cs,sln,csproj,config,xml}]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
SIM uses 2 spaces as indent size unlike Visual Studio which has got 4 by default. That is inconvenient when one have to adjust VS setting switching from one solution to another.

Likely, it is possible to [configure the code styles](https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options) on the solution level so that no changes in VS settings reqiured.