### PR TITLE
Fix error "You probably don't have necessary permissions..." in case of 'model' DB > 20MB

### DIFF
--- a/src/SIM.Adapters/SqlServer/SqlServerManager.cs
+++ b/src/SIM.Adapters/SqlServer/SqlServerManager.cs
@@ -557,8 +557,8 @@
     public virtual bool TestSqlServer(string rootPath, string connectionString)
     {
       var createDatabase =
-        $"CREATE DATABASE TestDatabase ON PRIMARY (NAME = TestDatabase_Data, FILENAME = '{rootPath}\\TestDatabase.mdf', SIZE = 20MB, MAXSIZE = 100MB, FILEGROWTH = 10%) " +
-        $"LOG ON (NAME = TestDatabase_Log, FILENAME = '{rootPath}\\TestDatabase.ldf', SIZE = 10MB, MAXSIZE = 50MB, FILEGROWTH = 10%)";
+        $"CREATE DATABASE TestDatabase ON PRIMARY (NAME = 'TestDatabase_Data', FILENAME = '{rootPath}\\TestDatabase.mdf') " +
+        $"LOG ON (NAME = 'TestDatabase_Log', FILENAME = '{rootPath}\\TestDatabase.ldf')";
 
       try
       {


### PR DESCRIPTION
During SIM installation, you may face the error "You probably don't have necessary permissions set. Please try to click 'Grant' button before you proceed." One of the possible reasons is the failure in TestSqlServer method which tries to create temporary database.