### PR TITLE
Use HTTPS when opening site in browser if available

### DIFF
--- a/src/SIM.Adapters/WebServer/Website.cs
+++ b/src/SIM.Adapters/WebServer/Website.cs
@@ -238,7 +238,9 @@
     [NotNull]
     public virtual string GetUrl([CanBeNull] string path = null)
     {
-      var binding = Bindings.FirstOrDefault();
+      var binding = Bindings
+        .OrderBy(x => string.Equals(x.Protocol, "https", StringComparison.OrdinalIgnoreCase) ? 0 : 1) // to use https when available
+        .FirstOrDefault();
       Assert.IsNotNull(binding, $"Website {ID} has no url bindings");
       var url = binding.Protocol + "://";
       var host = binding.Host;


### PR DESCRIPTION
With SIF it is started happening quite often that on dev machines Sitecore is running only via HTTPS with HTTP redirecting to HTTPS. For some reason, bypass admin feature doesn't work with these redirects therefore this PR makes SIM always choose HTTPS binding when it is available. 