### PR TITLE
#238 Add the button with the dropdown to select needed Sitecore XP version to install

### DIFF
--- a/src/SIM.Tool.Windows/MainWindowData.cs
+++ b/src/SIM.Tool.Windows/MainWindowData.cs
@@ -58,21 +58,30 @@ namespace SIM.Tool.Windows
           {
             new ButtonDefinition
             {
-              Label = "Install Instance",
+              Label = "Install SC XP 9",
               Image = "/Images/$lg/add_domain.png, SIM.Tool.Windows",
-              Handler = new SIM.Tool.Windows.MainWindowComponents.InstallInstanceButton()
+              Handler = new SIM.Tool.Windows.MainWindowComponents.Install9InstanceButton(),
+              Buttons = new[]
+              {
+                new ButtonDefinition
+                {
+                  Label = "Install Sitecore XP 9 and later",
+                  Image = "/Images/$lg/add_domain.png, SIM.Tool.Windows",
+                  Handler = new SIM.Tool.Windows.MainWindowComponents.Install9InstanceButton()
+                },
+                new ButtonDefinition
+                {
+                  Label = "Install Sitecore XP 8.2 and earlier",
+                  Image = "/Images/$lg/add_domain.png, SIM.Tool.Windows",
+                  Handler = new SIM.Tool.Windows.MainWindowComponents.InstallInstanceButton()
+                },
+              }
             },
             new ButtonDefinition
             {
               Label = "Import Solution",
               Image = "/Images/$lg/upload.png, SIM.Tool.Windows",
               Handler = new SIM.Tool.Windows.MainWindowComponents.ImportInstanceButton()
-            },
-            new ButtonDefinition
-            {
-              Label = "Install Sitecore 9",
-              Image = "/Images/$lg/add_domain.png, SIM.Tool.Windows",
-              Handler = new SIM.Tool.Windows.MainWindowComponents.Install9InstanceButton()
             }
           }
         },


### PR DESCRIPTION
The main label is named as **Install SC XP 9** instead of **Install Sitecore XP 9 and later** (as the dropdown option is named) in order to not overflow the size of the main window.