### PR TITLE
#Add removing files directories if they exist

### DIFF
--- a/src/SIM.Pipelines/Delete/CleanUp.cs
+++ b/src/SIM.Pipelines/Delete/CleanUp.cs
@@ -30,6 +30,29 @@ namespace SIM.Pipelines.Delete
       {
         Directory.Delete(param.Value, true);
       }
+      else if (param != null)
+      {
+        this.DeleteDirectoryWithFiles(param.Value);
+      }
+
+    }
+
+    private void DeleteDirectoryWithFiles(string target)
+    {
+      string[] files = Directory.GetFiles(target);
+      string[] dirs = Directory.GetDirectories(target);
+
+      foreach (string file in files)
+      {
+        File.Delete(file);
+      }
+
+      foreach (string dir in dirs)
+      {
+        DeleteDirectoryWithFiles(dir);
+      }
+
+      Directory.Delete(target, false);
     }
   }
 }


### PR DESCRIPTION
“IndexWorker” subfolder of the “XConnect” folder should be removed by SIF task.
If some of the files are used, it doesn't remove the directory with the files.

We have a CleanUp processor which cleans empty folder.

I've added a condition if there are any files/folder in the root folder, it recursively removes all files(since Directory.Delete(target, true); doesn't remove files) and folders, so at this moment of time search indexer shouldn't use any files.

closes #549 

Don't see a reason to implement retryer since the first removing of the files of IndexWorker happens in advance.